### PR TITLE
Simplify egui api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 The `show_with_blur` interface that enables blurring of egui windows has been simplified.
 
-This simplification is a breaking change. When upgrading from 0.2.0 to 0.3.0, calls to the `show_with_blur` function will need to be modified to remove the `id` parameter.
+This simplification is a breaking change. When upgrading from 0.2.0 to 0.3.0, calls to the `show_with_blur` function will need to be modified to remove the `id` and `blur_regions` parameters.
 
 ```rust
 // Before
@@ -18,7 +18,6 @@ egui::Window::new("Blur").frame(frame).show_with_blur(
 
 // After
 egui::Window::new("Blur").frame(frame).show_with_blur(
-    &mut blur_regions,
     contexts.ctx_mut(),
     |ui| ui.label("Blurry"),
 );
@@ -28,7 +27,8 @@ egui::Window::new("Blur").frame(frame).show_with_blur(
 
 ### Changed
 
-- egui: Removed the need to specify the window id in the `egui::Window::show_with_blur` function. The window id is now automatically detected.
+- egui: Removed the need to pass in the egui's window id into the `egui::Window::show_with_blur` function. The window id is now automatically detected.
+- egui: Removed the need to pass in the `BlurRegionsCamera` into the `egui::Window::show_with_blur` function when there is only one `BlurRegionsCamera`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,33 @@
 
 ## [Unreleased]
 
+#### Simplified egui integration
+
+The `show_with_blur` interface that enables blurring of egui windows has been simplified.
+
+This simplification is a breaking change. When upgrading from 0.2.0 to 0.3.0, calls to the `show_with_blur` function will need to be modified to remove the `id` parameter.
+
+```rust
+// Before
+egui::Window::new("Blur").frame(frame).show_with_blur(
+    egui::Id::new("Blur"),
+    &mut blur_regions,
+    contexts.ctx_mut(),
+    |ui| ui.label("Blurry"),
+
+// After
+egui::Window::new("Blur").frame(frame).show_with_blur(
+    &mut blur_regions,
+    contexts.ctx_mut(),
+    |ui| ui.label("Blurry"),
+);
+```
+
 ### Added
 
 ### Changed
+
+- egui: Removed the need to specify the window id in the `egui::Window::show_with_blur` function. The window id is now automatically detected.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ fn draw_ui(
 
     egui::Window::new("Blurry Window")
         .frame(frame)
-        .show_with_blur(egui::Id::new("Blurry Window"), &mut blur_regions, contexts.ctx_mut(), |ui| {
+        .show_with_blur(&mut blur_regions, contexts.ctx_mut(), |ui| {
             ui.label("This window has a nice blurry background.")
         });
 }

--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -41,21 +41,11 @@ fn update(
         .rounding(0.0)
         .shadow(egui::epaint::Shadow::NONE);
 
-    egui::Window::new("Blur").frame(frame).show_with_blur(
-        egui::Id::new("Blur"),
-        &mut blur_regions,
-        contexts.ctx_mut(),
-        |ui| {
-            ui.allocate_space(egui::vec2(300.0, 150.0));
-        },
-    );
+    egui::Window::new("Blur").frame(frame).show_with_blur(&mut blur_regions, contexts.ctx_mut(), |ui| {
+        ui.allocate_space(egui::vec2(300.0, 150.0));
+    });
 
-    egui::Window::new("Blur2").frame(frame).show_with_blur(
-        egui::Id::new("Blur2"),
-        &mut blur_regions,
-        contexts.ctx_mut(),
-        |ui| {
-            ui.allocate_space(egui::vec2(300.0, 150.0));
-        },
-    );
+    egui::Window::new("Blur2").frame(frame).show_with_blur(&mut blur_regions, contexts.ctx_mut(), |ui| {
+        ui.allocate_space(egui::vec2(300.0, 150.0));
+    });
 }

--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -32,20 +32,20 @@ fn setup(mut commands: Commands) {
 
 fn update(
     mut contexts: EguiContexts,
-    mut blur_region_cameras: Query<&mut bevy_blur_regions::DefaultBlurRegionsCamera>,
+    mut blur_region_cameras: Query<Entity, With<bevy_blur_regions::DefaultBlurRegionsCamera>>,
 ) {
-    let mut blur_regions = blur_region_cameras.single_mut();
+    let entity = blur_region_cameras.single_mut();
 
     let frame = egui::Frame::window(&contexts.ctx_mut().style())
         .fill(egui::Color32::from_rgba_premultiplied(27, 27, 27, 100))
         .rounding(0.0)
         .shadow(egui::epaint::Shadow::NONE);
 
-    egui::Window::new("Blur").frame(frame).show_with_blur(&mut blur_regions, contexts.ctx_mut(), |ui| {
+    egui::Window::new("Blur").frame(frame).show_with_blur(contexts.ctx_mut(), |ui| {
         ui.allocate_space(egui::vec2(300.0, 150.0));
     });
 
-    egui::Window::new("Blur2").frame(frame).show_with_blur(&mut blur_regions, contexts.ctx_mut(), |ui| {
+    egui::Window::new("Blur2").frame(frame).show_with_blur_on_camera(entity, contexts.ctx_mut(), |ui| {
         ui.allocate_space(egui::vec2(300.0, 150.0));
     });
 }

--- a/examples/settings.rs
+++ b/examples/settings.rs
@@ -52,7 +52,7 @@ fn update(
         .default_pos(egui::pos2(300.0 / 2.0, 720.0 / 2.0))
         .pivot(egui::Align2::CENTER_CENTER)
         .resizable(false)
-        .show_with_blur(egui::Id::new("Hint"), &mut blur_regions, contexts.ctx_mut(), |ui| {
+        .show_with_blur(&mut blur_regions, contexts.ctx_mut(), |ui| {
             ui.label("All blur regions on the same\ncamera share blur settings.");
         });
 
@@ -62,7 +62,7 @@ fn update(
         .default_pos(egui::pos2(1280.0 / 2.0, 720.0 / 2.0))
         .pivot(egui::Align2::CENTER_CENTER)
         .resizable(false)
-        .show_with_blur(egui::Id::new("Settings"), &mut blur_regions, contexts.ctx_mut(), |ui| {
+        .show_with_blur(&mut blur_regions, contexts.ctx_mut(), |ui| {
             ui.add_space(50.0);
             let radius_slider = egui::Slider::new(&mut radius, 0.0..=300.0).text("Radius").suffix("px");
             ui.add(radius_slider);

--- a/examples/settings.rs
+++ b/examples/settings.rs
@@ -52,7 +52,7 @@ fn update(
         .default_pos(egui::pos2(300.0 / 2.0, 720.0 / 2.0))
         .pivot(egui::Align2::CENTER_CENTER)
         .resizable(false)
-        .show_with_blur(&mut blur_regions, contexts.ctx_mut(), |ui| {
+        .show_with_blur(contexts.ctx_mut(), |ui| {
             ui.label("All blur regions on the same\ncamera share blur settings.");
         });
 
@@ -62,7 +62,7 @@ fn update(
         .default_pos(egui::pos2(1280.0 / 2.0, 720.0 / 2.0))
         .pivot(egui::Align2::CENTER_CENTER)
         .resizable(false)
-        .show_with_blur(&mut blur_regions, contexts.ctx_mut(), |ui| {
+        .show_with_blur(contexts.ctx_mut(), |ui| {
             ui.add_space(50.0);
             let radius_slider = egui::Slider::new(&mut radius, 0.0..=300.0).text("Radius").suffix("px");
             ui.add(radius_slider);

--- a/src/core.rs
+++ b/src/core.rs
@@ -75,6 +75,12 @@ impl<const N: usize> BlurRegionsCamera<N> {
         self.current_regions_count += 1;
     }
 
+    pub fn blur_all(&mut self, rects: &[Rect]) {
+        for rect in rects {
+            self.blur(*rect);
+        }
+    }
+
     fn clear(&mut self) {
         self.current_regions_count = 0;
     }
@@ -100,5 +106,8 @@ impl<const N: usize> Plugin for BlurRegionsPlugin<N> {
 
         #[cfg(feature = "bevy_ui")]
         app.add_plugins(crate::bevy_ui::BlurRegionsBevyUiPlugin::<N>);
+
+        #[cfg(feature = "egui")]
+        app.add_plugins(crate::egui::BlurRegionsEguiPlugin::<N>);
     }
 }

--- a/src/egui.rs
+++ b/src/egui.rs
@@ -7,7 +7,6 @@ use crate::BlurRegionsCamera;
 pub trait EguiWindowBlurExt {
     fn show_with_blur<R, const N: usize>(
         self,
-        id: egui::Id,
         blur_regions: &mut BlurRegionsCamera<N>,
         ctx: &egui::Context,
         add_contents: impl FnOnce(&mut egui::Ui) -> R,
@@ -17,21 +16,19 @@ pub trait EguiWindowBlurExt {
 impl<'open> EguiWindowBlurExt for egui::Window<'open> {
     fn show_with_blur<R, const N: usize>(
         self,
-        id: egui::Id,
         blur_regions: &mut BlurRegionsCamera<N>,
         ctx: &egui::Context,
         add_contents: impl FnOnce(&mut egui::Ui) -> R,
     ) -> Option<egui::InnerResponse<Option<R>>> {
-        let self_with_id = self.id(id);
-
-        let Some(response) = self_with_id.show(ctx, add_contents) else {
+        let Some(response) = self.show(ctx, add_contents) else {
             return None;
         };
 
         // egui appears to be painting one frame before bevy, so in order to ensure that the blur
         // is positioned exactly behind the window we need to ideally look at where the window was
         // one frame ago.
-        let egui_rect = ctx.memory(|memory| memory.area_rect(id)).unwrap_or(response.response.rect);
+        let egui_rect =
+            ctx.memory(|memory| memory.area_rect(response.response.layer_id.id)).unwrap_or(response.response.rect);
 
         let scale_factor = ctx.options(|op| op.zoom_factor);
         let min = vec2(egui_rect.min.x, egui_rect.min.y) * scale_factor;

--- a/src/egui.rs
+++ b/src/egui.rs
@@ -1,42 +1,192 @@
 use bevy::math::vec2;
 use bevy::prelude::*;
 use bevy_egui::egui;
+use bevy_egui::EguiContext;
 
+use crate::core::DEFAULT_MAX_BLUR_REGIONS_COUNT;
 use crate::BlurRegionsCamera;
 
+pub struct BlurRegionsEguiPlugin<const N: usize>;
+
+impl<const N: usize> Plugin for BlurRegionsEguiPlugin<N> {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Last, extract_egui_blurs::<N>);
+    }
+}
+
+#[derive(Clone)]
+enum EguiBlurTarget {
+    DefaultCamera,
+    Entity(Entity),
+}
+
+#[derive(Clone)]
+struct EguiBlurRegions<const N: usize> {
+    target: EguiBlurTarget,
+    current_regions_count: u32,
+    regions: [Rect; N],
+}
+
+impl<const N: usize> Default for EguiBlurRegions<N> {
+    fn default() -> Self {
+        EguiBlurRegions {
+            target: EguiBlurTarget::DefaultCamera,
+            current_regions_count: 0,
+            regions: std::array::from_fn(|_| Rect::new(-1.0, -1.0, -1.0, -1.0)),
+        }
+    }
+}
+
+impl<const N: usize> EguiBlurRegions<N> {
+    pub fn blur(&mut self, rect: Rect) {
+        if self.current_regions_count == N as u32 {
+            warn!("Blur region ignored as the max blur region count has already been reached");
+            return;
+        }
+
+        self.regions[self.current_regions_count as usize] = rect;
+        self.current_regions_count += 1;
+    }
+
+    fn clear(&mut self) {
+        self.current_regions_count = 0;
+    }
+}
+
 pub trait EguiWindowBlurExt {
-    fn show_with_blur<R, const N: usize>(
+    fn show_with_blur<R>(
         self,
-        blur_regions: &mut BlurRegionsCamera<N>,
+        ctx: &egui::Context,
+        add_contents: impl FnOnce(&mut egui::Ui) -> R,
+    ) -> Option<egui::InnerResponse<Option<R>>>;
+
+    fn show_with_blur_n<R, const N: usize>(
+        self,
+        ctx: &egui::Context,
+        add_contents: impl FnOnce(&mut egui::Ui) -> R,
+    ) -> Option<egui::InnerResponse<Option<R>>>;
+
+    fn show_with_blur_on_camera<R>(
+        self,
+        camera_entity: Entity,
+        ctx: &egui::Context,
+        add_contents: impl FnOnce(&mut egui::Ui) -> R,
+    ) -> Option<egui::InnerResponse<Option<R>>>;
+
+    fn show_with_blur_on_camera_n<R, const N: usize>(
+        self,
+        camera_entity: Entity,
         ctx: &egui::Context,
         add_contents: impl FnOnce(&mut egui::Ui) -> R,
     ) -> Option<egui::InnerResponse<Option<R>>>;
 }
 
+fn get_egui_blur_rect<R>(
+    window: egui::Window<'_>,
+    ctx: &egui::Context,
+    add_contents: impl FnOnce(&mut egui::Ui) -> R,
+) -> Option<(egui::InnerResponse<Option<R>>, Rect)> {
+    let Some(response) = window.show(ctx, add_contents) else {
+        return None;
+    };
+
+    // egui appears to be painting one frame before bevy, so in order to ensure that the blur
+    // is positioned exactly behind the window we need to ideally look at where the window was
+    // one frame ago.
+    let egui_rect =
+        ctx.memory(|memory| memory.area_rect(response.response.layer_id.id)).unwrap_or(response.response.rect);
+
+    let scale_factor = ctx.options(|op| op.zoom_factor);
+    let min = vec2(egui_rect.min.x, egui_rect.min.y) * scale_factor;
+    let max = vec2(egui_rect.max.x, egui_rect.max.y) * scale_factor;
+
+    Some((response, Rect::from_corners(min, max)))
+}
+
 impl<'open> EguiWindowBlurExt for egui::Window<'open> {
-    fn show_with_blur<R, const N: usize>(
+    fn show_with_blur<R>(
         self,
-        blur_regions: &mut BlurRegionsCamera<N>,
         ctx: &egui::Context,
         add_contents: impl FnOnce(&mut egui::Ui) -> R,
     ) -> Option<egui::InnerResponse<Option<R>>> {
-        let Some(response) = self.show(ctx, add_contents) else {
-            return None;
-        };
+        self.show_with_blur_n::<R, DEFAULT_MAX_BLUR_REGIONS_COUNT>(ctx, add_contents)
+    }
 
-        // egui appears to be painting one frame before bevy, so in order to ensure that the blur
-        // is positioned exactly behind the window we need to ideally look at where the window was
-        // one frame ago.
-        let egui_rect =
-            ctx.memory(|memory| memory.area_rect(response.response.layer_id.id)).unwrap_or(response.response.rect);
+    fn show_with_blur_n<R, const N: usize>(
+        self,
+        ctx: &egui::Context,
+        add_contents: impl FnOnce(&mut egui::Ui) -> R,
+    ) -> Option<egui::InnerResponse<Option<R>>> {
+        let (response, blur_rect) = get_egui_blur_rect(self, ctx, add_contents)?;
 
-        let scale_factor = ctx.options(|op| op.zoom_factor);
-        let min = vec2(egui_rect.min.x, egui_rect.min.y) * scale_factor;
-        let max = vec2(egui_rect.max.x, egui_rect.max.y) * scale_factor;
-
-        let blur_rect = Rect::from_corners(min, max);
-        blur_regions.blur(blur_rect);
+        ctx.memory_mut(|mem| {
+            let egui_blur_regions: &mut EguiBlurRegions<N> = mem.data.get_temp_mut_or_default(egui::Id::NULL);
+            egui_blur_regions.target = EguiBlurTarget::DefaultCamera;
+            egui_blur_regions.blur(blur_rect);
+        });
 
         Some(response)
+    }
+
+    fn show_with_blur_on_camera<R>(
+        self,
+        camera_entity: Entity,
+        ctx: &egui::Context,
+        add_contents: impl FnOnce(&mut egui::Ui) -> R,
+    ) -> Option<egui::InnerResponse<Option<R>>> {
+        self.show_with_blur_on_camera_n::<R, DEFAULT_MAX_BLUR_REGIONS_COUNT>(camera_entity, ctx, add_contents)
+    }
+
+    fn show_with_blur_on_camera_n<R, const N: usize>(
+        self,
+        camera_entity: Entity,
+        ctx: &egui::Context,
+        add_contents: impl FnOnce(&mut egui::Ui) -> R,
+    ) -> Option<egui::InnerResponse<Option<R>>> {
+        let (response, blur_rect) = get_egui_blur_rect(self, ctx, add_contents)?;
+
+        ctx.memory_mut(|mem| {
+            let egui_blur_regions: &mut EguiBlurRegions<N> = mem.data.get_temp_mut_or_default(egui::Id::NULL);
+            egui_blur_regions.target = EguiBlurTarget::Entity(camera_entity);
+            egui_blur_regions.blur(blur_rect);
+        });
+
+        Some(response)
+    }
+}
+
+pub fn extract_egui_blurs<const N: usize>(
+    mut contexts: Query<&'static mut EguiContext>,
+    mut blur_region_cameras: Query<&mut BlurRegionsCamera<N>>,
+) {
+    for mut context in &mut contexts {
+        let ctx = context.get_mut();
+
+        ctx.memory_mut(|mem| {
+            let egui_blur_regions: &mut EguiBlurRegions<N> = mem.data.get_temp_mut_or_default(egui::Id::NULL);
+
+            match egui_blur_regions.target {
+                EguiBlurTarget::DefaultCamera => {
+                    if let Ok(mut blur_regions) = blur_region_cameras.get_single_mut() {
+                        blur_regions.blur_all(
+                            &egui_blur_regions.regions[0..=(egui_blur_regions.current_regions_count as usize)],
+                        );
+                    } else {
+                        debug!("No default BlurRegionsCamera exists, skipping blurring.");
+                    }
+                }
+                EguiBlurTarget::Entity(entity) => {
+                    if let Ok(mut blur_regions) = blur_region_cameras.get_mut(entity) {
+                        blur_regions.blur_all(
+                            &egui_blur_regions.regions[0..=(egui_blur_regions.current_regions_count as usize)],
+                        );
+                    } else {
+                        debug!("No BlurRegionsCamera exists for entity {entity:?}, skipping blurring.");
+                    }
+                }
+            };
+
+            egui_blur_regions.clear();
+        });
     }
 }


### PR DESCRIPTION
Removes the `id` and `blur_regions` parameters from the egui `show_with_blur` function.

The `id` parameter is no longer needed because it can be inferred from the the egui response.

The `blur_regions` parameter is probably not needed in most cases when there is only one `BlurRegionsCamera`. However, if there do exist many `BlurRegionsCamera`s then the `show_with_blur_on_camera` function can be used instead.

```rust
// Before
egui::Window::new("Blur").frame(frame).show_with_blur(
    egui::Id::new("Blur"),
    &mut blur_regions,
    contexts.ctx_mut(),
    |ui| ui.label("Blurry"),

// After
egui::Window::new("Blur").frame(frame).show_with_blur(
    contexts.ctx_mut(),
    |ui| ui.label("Blurry"),
);
```