### PR TITLE
Hdr specialization and deband dithering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,11 @@ egui::Window::new("Blur").frame(frame).show_with_blur(
 
 ### Added
 
+- Add support for HDR render targets.
+
 ### Changed
 
-- bevy: Upgrade to Bevy 0.14
+- bevy: Upgrade to Bevy 0.14.
 - Improve the blurring algorithm. The new implementation utilises the gaussian blur implementation originally contributed to bevy for the depth of field feature.
 - egui: Removed the need to pass in the egui's window id into the `egui::Window::show_with_blur` function. The window id is now automatically detected.
 - egui: Removed the need to pass in the `BlurRegionsCamera` into the `egui::Window::show_with_blur` function when there is only one `BlurRegionsCamera`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ egui::Window::new("Blur").frame(frame).show_with_blur(
 ### Added
 
 - Add support for HDR render targets.
+- Add support for deband dithering during tonemapping.
 
 ### Changed
 

--- a/examples/deband_dither.rs
+++ b/examples/deband_dither.rs
@@ -1,0 +1,59 @@
+// The blurring algorithm has the tendancy to introduce banding.
+// This example demonstrates how to use Bevy's standard tonemapping
+// and deband dithering to improve the appearance of the blurring.
+//   cargo run --example deband_dither
+
+use bevy::core_pipeline::tonemapping::DebandDither;
+use bevy::math::vec2;
+use bevy::prelude::*;
+use bevy_blur_regions::prelude::*;
+
+#[path = "./utils.rs"]
+mod utils;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(BlurRegionsPlugin::default())
+        .add_systems(Startup, (setup, utils::spawn_example_scene))
+        .add_systems(Update, update)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn((
+        DefaultBlurRegionsCamera::default(),
+        Camera3dBundle {
+            // Enable HDR on the camera to enable tonemapping.
+            // Fullscreen dithering runs in the tonemapping shader, which is
+            // only enabled when HDR is enabled.
+            camera: Camera { hdr: true, ..default() },
+            // Enable deband dithering.
+            deband_dither: DebandDither::Enabled,
+            transform: Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
+            ..default()
+        },
+    ));
+}
+
+fn update(windows: Query<&Window>, mut blur_region_cameras: Query<&mut DefaultBlurRegionsCamera>) {
+    let Ok(window) = windows.get_single() else {
+        return;
+    };
+    let Ok(mut blur_regions) = blur_region_cameras.get_single_mut() else {
+        return;
+    };
+
+    let screen_size = Vec2::new(
+        window.resolution.physical_width() as f32,
+        window.resolution.physical_height() as f32,
+    );
+    blur_regions.blur(Rect::from_center_size(
+        vec2(0.25, 0.5) * screen_size,
+        vec2(0.3, 0.5) * screen_size,
+    ));
+    blur_regions.blur(Rect::from_center_size(
+        vec2(0.75, 0.5) * screen_size,
+        vec2(0.3, 0.5) * screen_size,
+    ));
+}

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -3,6 +3,7 @@ use bevy::core_pipeline::core_3d::graph::Core3d;
 use bevy::core_pipeline::core_3d::graph::Node3d;
 use bevy::core_pipeline::fullscreen_vertex_shader::fullscreen_shader_vertex_state;
 use bevy::ecs::query::QueryItem;
+use bevy::ecs::system::lifetimeless::Read;
 use bevy::prelude::*;
 use bevy::render::extract_component::ComponentUniforms;
 use bevy::render::extract_component::ExtractComponentPlugin;
@@ -35,13 +36,18 @@ use bevy::render::render_resource::SamplerBindingType;
 use bevy::render::render_resource::SamplerDescriptor;
 use bevy::render::render_resource::ShaderDefVal;
 use bevy::render::render_resource::ShaderStages;
+use bevy::render::render_resource::SpecializedRenderPipeline;
+use bevy::render::render_resource::SpecializedRenderPipelines;
 use bevy::render::render_resource::TextureFormat;
 use bevy::render::render_resource::TextureSampleType;
 use bevy::render::renderer::RenderContext;
 use bevy::render::renderer::RenderDevice;
 use bevy::render::texture::BevyDefault;
+use bevy::render::view::ExtractedView;
 use bevy::render::view::ViewTarget;
+use bevy::render::Render;
 use bevy::render::RenderApp;
+use bevy::render::RenderSet;
 
 use crate::BlurRegionsCamera;
 
@@ -63,6 +69,11 @@ impl<const N: usize> Plugin for BlurRegionsShaderPlugin<N> {
         };
 
         render_app
+            .init_resource::<SpecializedRenderPipelines<BlurRegionsPipeline<N>>>()
+            .add_systems(
+                Render,
+                (prepare_blur_regions_pipelines::<N>.in_set(RenderSet::Prepare),),
+            )
             .add_render_graph_node::<ViewNodeRunner<BlurRegionsNode<N>>>(Core3d, BlurRegionsLabel)
             .add_render_graph_edges(
                 Core3d,
@@ -75,7 +86,8 @@ impl<const N: usize> Plugin for BlurRegionsShaderPlugin<N> {
             return;
         };
 
-        render_app.init_resource::<BlurRegionsPipeline<N>>();
+        let render_device = render_app.world().resource::<RenderDevice>().clone();
+        render_app.insert_resource(BlurRegionsPipeline::<N>::new(&render_device));
     }
 }
 
@@ -86,13 +98,13 @@ pub struct BlurRegionsLabel;
 pub struct BlurRegionsNode<const N: usize>;
 
 impl<const N: usize> ViewNode for BlurRegionsNode<N> {
-    type ViewQuery = (&'static ViewTarget, &'static BlurRegionsCamera<N>);
+    type ViewQuery = (Read<ViewTarget>, Read<BlurRegionsPasses>);
 
     fn run(
         &self,
         _graph: &mut RenderGraphContext,
         render_context: &mut RenderContext,
-        (view_target, _blur_regions_camera): QueryItem<Self::ViewQuery>,
+        (view_target, passes): QueryItem<Self::ViewQuery>,
         world: &World,
     ) -> Result<(), NodeRunError> {
         let blur_regions_pipeline = world.resource::<BlurRegionsPipeline<N>>();
@@ -103,7 +115,7 @@ impl<const N: usize> ViewNode for BlurRegionsNode<N> {
             return Ok(());
         };
 
-        for pass in &blur_regions_pipeline.passes {
+        for pass in &passes.0 {
             let Some(pass_pipeline) = pipeline_cache.get_render_pipeline(pass.pipeline) else {
                 return Ok(());
             };
@@ -120,7 +132,7 @@ impl<const N: usize> ViewNode for BlurRegionsNode<N> {
                 )),
             );
 
-            let mut horizontal_render_pass = render_context.begin_tracked_render_pass(RenderPassDescriptor {
+            let mut render_pass = render_context.begin_tracked_render_pass(RenderPassDescriptor {
                 label: Some(pass.pass_label),
                 color_attachments: &[Some(RenderPassColorAttachment {
                     view: post_process.destination,
@@ -132,9 +144,9 @@ impl<const N: usize> ViewNode for BlurRegionsNode<N> {
                 occlusion_query_set: None,
             });
 
-            horizontal_render_pass.set_render_pipeline(pass_pipeline);
-            horizontal_render_pass.set_bind_group(0, &bind_group, &[]);
-            horizontal_render_pass.draw(0..3, 0..1);
+            render_pass.set_render_pipeline(pass_pipeline);
+            render_pass.set_bind_group(0, &bind_group, &[]);
+            render_pass.draw(0..3, 0..1);
         }
 
         Ok(())
@@ -145,19 +157,10 @@ impl<const N: usize> ViewNode for BlurRegionsNode<N> {
 pub struct BlurRegionsPipeline<const N: usize> {
     layout: BindGroupLayout,
     sampler: Sampler,
-    passes: [BlurRegionsPass; 2],
 }
 
-pub struct BlurRegionsPass {
-    pass_label: &'static str,
-    bind_group_label: &'static str,
-    pipeline: CachedRenderPipelineId,
-}
-
-impl<const N: usize> FromWorld for BlurRegionsPipeline<N> {
-    fn from_world(world: &mut World) -> Self {
-        let render_device = world.resource::<RenderDevice>();
-
+impl<const N: usize> BlurRegionsPipeline<N> {
+    fn new(render_device: &RenderDevice) -> Self {
         let layout = render_device.create_bind_group_layout(
             "blur_regions_bind_group_layout",
             &BindGroupLayoutEntries::sequential(
@@ -169,65 +172,101 @@ impl<const N: usize> FromWorld for BlurRegionsPipeline<N> {
                 ),
             ),
         );
-
         let sampler = render_device.create_sampler(&SamplerDescriptor::default());
-        let mut pipeline_cache = world.resource_mut::<PipelineCache>();
 
-        let passes = [
-            make_pipeline::<N>(
-                &mut pipeline_cache,
-                layout.clone(),
-                "horizontal",
-                "blur regions (horizontal pass)",
-                "blur regions bind group (horizontal pass)",
-            ),
-            make_pipeline::<N>(
-                &mut pipeline_cache,
-                layout.clone(),
-                "vertical",
-                "blur regions (vertical pass)",
-                "blur regions bind group (vertical pass)",
-            ),
-        ];
-
-        Self {
-            layout,
-            sampler,
-            passes,
-        }
+        Self { layout, sampler }
     }
 }
 
-fn make_pipeline<const N: usize>(
-    pipeline_cache: &mut PipelineCache,
-    layout: BindGroupLayout,
-    entrypoint: &'static str,
+#[derive(Component)]
+pub struct BlurRegionsPasses([BlurRegionsPass; 2]);
+
+pub struct BlurRegionsPass {
     pass_label: &'static str,
     bind_group_label: &'static str,
-) -> BlurRegionsPass {
-    let descriptor = RenderPipelineDescriptor {
-        label: Some("blur_regions_pipeline".into()),
-        layout: vec![layout],
-        vertex: fullscreen_shader_vertex_state(),
-        fragment: Some(FragmentState {
-            shader: SHADER_HANDLE,
-            shader_defs: vec![ShaderDefVal::UInt("MAX_BLUR_REGIONS_COUNT".into(), N as u32)],
-            entry_point: entrypoint.into(),
-            targets: vec![Some(ColorTargetState {
-                format: TextureFormat::bevy_default(),
-                blend: None,
-                write_mask: ColorWrites::ALL,
-            })],
-        }),
-        primitive: PrimitiveState::default(),
-        depth_stencil: None,
-        multisample: MultisampleState::default(),
-        push_constant_ranges: vec![],
-    };
-    let pipeline = pipeline_cache.queue_render_pipeline(descriptor);
-    BlurRegionsPass {
-        pass_label,
-        bind_group_label,
-        pipeline,
+    pipeline: CachedRenderPipelineId,
+}
+
+#[derive(PartialEq, Eq, Hash, Clone, Copy)]
+pub struct BlurRegionsPipelineKey {
+    pass: BlurRegionsPassKey,
+    hdr: bool,
+}
+
+
+#[derive(PartialEq, Eq, Hash, Clone, Copy)]
+enum BlurRegionsPassKey {
+    Horizontal,
+    Vertical,
+}
+
+fn prepare_blur_regions_pipelines<const N: usize>(
+    mut commands: Commands,
+    pipeline_cache: Res<PipelineCache>,
+    mut pipelines: ResMut<SpecializedRenderPipelines<BlurRegionsPipeline<N>>>,
+    pipeline: Res<BlurRegionsPipeline<N>>,
+    views: Query<(Entity, &ExtractedView), With<BlurRegionsCamera<N>>>,
+) {
+    for (entity, view) in &views {
+        let horizontal_pass = BlurRegionsPass {
+            pass_label: "blur regions (horizontal pass)",
+            bind_group_label: "blur regions bind group (horizontal pass)",
+            pipeline: pipelines.specialize(
+                &pipeline_cache,
+                &pipeline,
+                BlurRegionsPipelineKey {
+                    pass: BlurRegionsPassKey::Horizontal,
+                    hdr: view.hdr,
+                },
+            ),
+        };
+
+        let vertical_pass = BlurRegionsPass {
+            pass_label: "blur regions (vertical pass)",
+            bind_group_label: "blur regions bind group (vertical pass)",
+            pipeline: pipelines.specialize(
+                &pipeline_cache,
+                &pipeline,
+                BlurRegionsPipelineKey {
+                    pass: BlurRegionsPassKey::Vertical,
+                    hdr: view.hdr,
+                },
+            ),
+        };
+
+        commands.entity(entity).insert(BlurRegionsPasses([horizontal_pass, vertical_pass]));
+    }
+}
+
+impl<const N: usize> SpecializedRenderPipeline for BlurRegionsPipeline<N> {
+    type Key = BlurRegionsPipelineKey;
+
+    fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
+        RenderPipelineDescriptor {
+            label: Some("blur_regions_pipeline".into()),
+            layout: vec![self.layout.clone()],
+            vertex: fullscreen_shader_vertex_state(),
+            primitive: PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: MultisampleState::default(),
+            push_constant_ranges: vec![],
+            fragment: Some(FragmentState {
+                shader: SHADER_HANDLE,
+                shader_defs: vec![ShaderDefVal::UInt("MAX_BLUR_REGIONS_COUNT".into(), N as u32)],
+                entry_point: match key.pass {
+                    BlurRegionsPassKey::Horizontal => "horizontal".into(),
+                    BlurRegionsPassKey::Vertical => "vertical".into(),
+                },
+                targets: vec![Some(ColorTargetState {
+                    format: if key.hdr {
+                        ViewTarget::TEXTURE_FORMAT_HDR
+                    } else {
+                        TextureFormat::bevy_default()
+                    },
+                    blend: None,
+                    write_mask: ColorWrites::ALL,
+                })],
+            }),
+        }
     }
 }

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -75,10 +75,7 @@ impl<const N: usize> Plugin for BlurRegionsShaderPlugin<N> {
                 (prepare_blur_regions_pipelines::<N>.in_set(RenderSet::Prepare),),
             )
             .add_render_graph_node::<ViewNodeRunner<BlurRegionsNode<N>>>(Core3d, BlurRegionsLabel)
-            .add_render_graph_edges(
-                Core3d,
-                (Node3d::Tonemapping, BlurRegionsLabel, Node3d::EndMainPassPostProcessing),
-            );
+            .add_render_graph_edges(Core3d, (Node3d::DepthOfField, BlurRegionsLabel, Node3d::Tonemapping));
     }
 
     fn finish(&self, app: &mut App) {
@@ -192,7 +189,6 @@ pub struct BlurRegionsPipelineKey {
     pass: BlurRegionsPassKey,
     hdr: bool,
 }
-
 
 #[derive(PartialEq, Eq, Hash, Clone, Copy)]
 enum BlurRegionsPassKey {


### PR DESCRIPTION
Adds pipeline specialization for hdr render targets, as well as ensuring that the blur shader runs before tonemapping to make use of Bevy's standard deband dithering.