### PR TITLE
Improvements to blur look

### DIFF
--- a/src/shader.rs
+++ b/src/shader.rs
@@ -77,9 +77,11 @@ impl<const N: usize> Plugin for BlurRegionsShaderPlugin<N> {
                 (prepare_blur_regions_pipelines::<N>.in_set(RenderSet::Prepare),),
             )
             .add_render_graph_node::<ViewNodeRunner<BlurRegionsNode<N>>>(Core3d, BlurRegionsLabel)
-            .add_render_graph_edges(Core3d, (Node3d::DepthOfField, BlurRegionsLabel, Node3d::Tonemapping))
+            .add_render_graph_edges(Core3d, (Node3d::Tonemapping, BlurRegionsLabel, Node3d::Smaa))
+            .add_render_graph_edges(Core3d, (BlurRegionsLabel, Node3d::Fxaa))
             .add_render_graph_node::<ViewNodeRunner<BlurRegionsNode<N>>>(Core2d, BlurRegionsLabel)
-            .add_render_graph_edges(Core2d, (Node2d::Bloom, BlurRegionsLabel, Node2d::Tonemapping));
+            .add_render_graph_edges(Core2d, (Node2d::Tonemapping, BlurRegionsLabel, Node2d::Smaa))
+            .add_render_graph_edges(Core2d, (BlurRegionsLabel, Node2d::Fxaa));
     }
 
     fn finish(&self, app: &mut App) {

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -19,7 +19,7 @@ use bevy::render::render_graph::ViewNodeRunner;
 use bevy::render::render_resource::binding_types::sampler;
 use bevy::render::render_resource::binding_types::texture_2d;
 use bevy::render::render_resource::binding_types::uniform_buffer;
-use bevy::render::render_resource::BindGroupEntries;
+use bevy::render::render_resource::{AddressMode, BindGroupEntries};
 use bevy::render::render_resource::BindGroupLayout;
 use bevy::render::render_resource::BindGroupLayoutEntries;
 use bevy::render::render_resource::CachedRenderPipelineId;
@@ -175,7 +175,11 @@ impl<const N: usize> BlurRegionsPipeline<N> {
                 ),
             ),
         );
-        let sampler = render_device.create_sampler(&SamplerDescriptor::default());
+        let sampler = render_device.create_sampler(&SamplerDescriptor {
+            address_mode_u: AddressMode::MirrorRepeat,
+            address_mode_v: AddressMode::MirrorRepeat,
+            ..default()
+        });
 
         Self { layout, sampler }
     }


### PR DESCRIPTION
This PR tweaks a few things to produce more aethestic results. No changes to the shaders have been made, making these changes easy to review ;)

1. The blur node has been moved after tonemapping. Before, blurring would create boxy regions around bright values, but moving the blurring after the tonemapping means no large values are present anymore, preventing those boxy regions from appearing.
2. The addressing mode on the blur input sampler has been changed to "Mirrored Repeat", reducing the streaking at the edges, as well as the apparent brightening on the edges of the image. This is less visible but still makes a good change in scenes with a lot of dynamic range (e.g. space scenes).

Here's a before and after of this change:

Before:

<img width="375" alt="Screenshot 2024-12-02 at 11 41 49" src="https://github.com/user-attachments/assets/2c865908-88ba-435c-b4e8-3d7a88d246e0">

After:

<img width="377" alt="Screenshot 2024-12-02 at 11 43 30" src="https://github.com/user-attachments/assets/1bf0a469-980c-49aa-9223-379ab974404c">
