### PR TITLE
Feat/bevy0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ repository = "https://github.com/atbentley/bevy_blur_regions"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-bevy = { version = "0.14", default-features = false, features = ["bevy_render"] }
-bevy_egui = { version = "0.30", optional = true }
+bevy = { version = "0.15", default-features = false, features = ["bevy_render"] }
+bevy_egui = { version = "0.31", optional = true }
 
 [features]
 all = ["bevy_ui", "egui"]
@@ -22,7 +22,7 @@ bevy_ui = ["bevy/bevy_ui"]
 egui = ["dep:bevy_egui"]
 
 [dev-dependencies]
-bevy = { version = "0.14" }
+bevy = { version = "0.15" }
 
 [[example]]
 name = "2d_egui"

--- a/examples/2d_egui.rs
+++ b/examples/2d_egui.rs
@@ -21,7 +21,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn((Camera2dBundle::default(), DefaultBlurRegionsCamera::default()));
+    commands.spawn((Camera2d::default(), DefaultBlurRegionsCamera::default()));
 }
 
 fn update(

--- a/examples/bevy_ui.rs
+++ b/examples/bevy_ui.rs
@@ -20,42 +20,37 @@ fn setup(mut commands: Commands) {
     // 3D camera
     commands.spawn((
         BlurRegionsCamera::default(),
-        Camera3dBundle {
-            camera: Camera { order: 1, ..default() },
-            transform: Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..default()
-        },
+        Camera3d::default(),
+        Camera { order: 1, ..default() },
+        Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
     ));
 
     // UI camera
-    commands.spawn(Camera2dBundle {
-        camera: Camera { order: 2, ..default() },
-        ..default()
-    });
+    commands.spawn((
+        Camera2d::default(),
+        Camera { order: 2, ..default() }
+        ));
 
     // UI node with blur region
     commands.spawn((
         BlurRegion,
-        NodeBundle {
-            border_color: Color::BLACK.into(),
-            border_radius: BorderRadius::new(Val::ZERO, Val::Percent(5.0), Val::Percent(10.0), Val::Percent(15.0)),
-            style: Style {
-                width: Val::Percent(50.0),
-                height: Val::Percent(50.0),
-                border: UiRect::all(Val::Px(5.0)),
-                ..default()
-            },
+        Node {
+            width: Val::Percent(50.0),
+            height: Val::Percent(50.0),
+            border: UiRect::all(Val::Px(5.0)),
             ..default()
         },
+        BorderColor(Color::BLACK),
+        BorderRadius::new(Val::ZERO, Val::Percent(5.0), Val::Percent(10.0), Val::Percent(15.0)),
     ));
 }
 
-fn move_node(time: Res<Time>, mut nodes: Query<(&mut Style, &mut Visibility)>) {
-    for (mut style, mut visibility) in &mut nodes {
-        style.left = Val::Percent((time.elapsed_seconds().cos() + 1.0) / 2.0 * 50.0);
-        style.top = Val::Percent((time.elapsed_seconds().sin() + 1.0) / 2.0 * 50.0);
+fn move_node(time: Res<Time>, mut nodes: Query<(&mut Node, &mut Visibility)>) {
+    for (mut node, mut visibility) in &mut nodes {
+        node.left = Val::Percent((time.elapsed_secs().cos() + 1.0) / 2.0 * 50.0);
+        node.top = Val::Percent((time.elapsed_secs().sin() + 1.0) / 2.0 * 50.0);
 
-        *visibility = if time.elapsed_seconds() % 2. < 1. {
+        *visibility = if time.elapsed_secs() % 2. < 1. {
             Visibility::Visible
         } else {
             Visibility::Hidden

--- a/examples/deband_dither.rs
+++ b/examples/deband_dither.rs
@@ -23,16 +23,10 @@ fn main() {
 fn setup(mut commands: Commands) {
     commands.spawn((
         DefaultBlurRegionsCamera::default(),
-        Camera3dBundle {
-            // Enable HDR on the camera to enable tonemapping.
-            // Fullscreen dithering runs in the tonemapping shader, which is
-            // only enabled when HDR is enabled.
-            camera: Camera { hdr: true, ..default() },
-            // Enable deband dithering.
-            deband_dither: DebandDither::Enabled,
-            transform: Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..default()
-        },
+        Camera3d::default(),
+        Camera { hdr: true, ..default() },
+        Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
+        DebandDither::Enabled,
     ));
 }
 

--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -23,10 +23,8 @@ fn main() {
 fn setup(mut commands: Commands) {
     commands.spawn((
         DefaultBlurRegionsCamera::default(),
-        Camera3dBundle {
-            transform: Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..default()
-        },
+        Camera3d::default(),
+        Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
     ));
 }
 

--- a/examples/immediate.rs
+++ b/examples/immediate.rs
@@ -20,10 +20,8 @@ fn main() {
 fn setup(mut commands: Commands) {
     commands.spawn((
         DefaultBlurRegionsCamera::default(),
-        Camera3dBundle {
-            transform: Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..default()
-        },
+        Camera3d::default(),
+        Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
     ));
 }
 

--- a/examples/no_regions.rs
+++ b/examples/no_regions.rs
@@ -18,9 +18,7 @@ fn main() {
 fn setup(mut commands: Commands) {
     commands.spawn((
         BlurRegionsCamera::default(),
-        Camera3dBundle {
-            transform: Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..default()
-        },
+        Camera3d::default(),
+        Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
     ));
 }

--- a/examples/settings.rs
+++ b/examples/settings.rs
@@ -23,10 +23,8 @@ fn main() {
 fn setup(mut commands: Commands) {
     commands.spawn((
         DefaultBlurRegionsCamera::default(),
-        Camera3dBundle {
-            transform: Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..default()
-        },
+        Camera3d::default(),
+        Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
     ));
 }
 

--- a/examples/utils.rs
+++ b/examples/utils.rs
@@ -1,6 +1,4 @@
 use bevy::prelude::*;
-use bevy::sprite::MaterialMesh2dBundle;
-use bevy::sprite::Mesh2dHandle;
 
 #[allow(dead_code)]
 pub fn spawn_example_scene_3d(
@@ -8,26 +6,23 @@ pub fn spawn_example_scene_3d(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands.spawn((PbrBundle {
-        mesh: meshes.add(Rectangle::new(10.0, 10.0)),
-        material: materials.add(Color::WHITE),
-        transform: Transform::from_rotation(Quat::from_rotation_x(-std::f32::consts::FRAC_PI_2)),
-        ..default()
-    },));
-    commands.spawn((PbrBundle {
-        mesh: meshes.add(Capsule3d::new(0.5, 1.0)),
-        material: materials.add(Color::srgb_u8(124, 144, 255)),
-        transform: Transform::from_xyz(0.0, 1.01, 0.0),
-        ..default()
-    },));
-    commands.spawn(PointLightBundle {
-        point_light: PointLight {
+    commands.spawn((
+        Mesh2d(meshes.add(Rectangle::new(10.0, 10.0))),
+        MeshMaterial3d(materials.add(Color::WHITE)),
+        Transform::from_rotation(Quat::from_rotation_x(-std::f32::consts::FRAC_PI_2)),
+    ));
+    commands.spawn((
+        Mesh3d(meshes.add(Capsule3d::new(0.5, 1.0))),
+        MeshMaterial3d(materials.add(Color::srgb_u8(124, 144, 255))),
+        Transform::from_xyz(0.0, 1.01, 0.0),
+    ));
+    commands.spawn((
+        PointLight {
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::from_xyz(4.0, 8.0, 4.0),
-        ..default()
-    });
+        Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
 }
 
 #[allow(dead_code)]
@@ -37,16 +32,16 @@ pub fn spawn_example_scene_2d(
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     let shapes = [
-        Mesh2dHandle(meshes.add(Circle { radius: 50.0 })),
-        Mesh2dHandle(meshes.add(CircularSector::new(50.0, 1.0))),
-        Mesh2dHandle(meshes.add(CircularSegment::new(50.0, 1.25))),
-        Mesh2dHandle(meshes.add(Ellipse::new(25.0, 50.0))),
-        Mesh2dHandle(meshes.add(Annulus::new(25.0, 50.0))),
-        Mesh2dHandle(meshes.add(Capsule2d::new(25.0, 50.0))),
-        Mesh2dHandle(meshes.add(Rhombus::new(75.0, 100.0))),
-        Mesh2dHandle(meshes.add(Rectangle::new(50.0, 100.0))),
-        Mesh2dHandle(meshes.add(RegularPolygon::new(50.0, 6))),
-        Mesh2dHandle(meshes.add(Triangle2d::new(
+        Mesh2d(meshes.add(Circle { radius: 50.0 })),
+        Mesh2d(meshes.add(CircularSector::new(50.0, 1.0))),
+        Mesh2d(meshes.add(CircularSegment::new(50.0, 1.25))),
+        Mesh2d(meshes.add(Ellipse::new(25.0, 50.0))),
+        Mesh2d(meshes.add(Annulus::new(25.0, 50.0))),
+        Mesh2d(meshes.add(Capsule2d::new(25.0, 50.0))),
+        Mesh2d(meshes.add(Rhombus::new(75.0, 100.0))),
+        Mesh2d(meshes.add(Rectangle::new(50.0, 100.0))),
+        Mesh2d(meshes.add(RegularPolygon::new(50.0, 6))),
+        Mesh2d(meshes.add(Triangle2d::new(
             Vec2::Y * 50.0,
             Vec2::new(-50.0, -50.0),
             Vec2::new(50.0, -50.0),
@@ -59,17 +54,11 @@ pub fn spawn_example_scene_2d(
         // Distribute colors evenly across the rainbow.
         let color = Color::hsl(360. * i as f32 / num_shapes as f32, 0.95, 0.7);
 
-        commands.spawn(MaterialMesh2dBundle {
-            mesh: shape,
-            material: materials.add(color),
-            transform: Transform::from_xyz(
-                // Distribute shapes from -X_EXTENT/2 to +X_EXTENT/2.
-                -extent / 2. + i as f32 / (num_shapes - 1) as f32 * extent,
-                0.0,
-                0.0,
-            ),
-            ..default()
-        });
+        commands.spawn((
+            shape,
+            MeshMaterial2d(materials.add(color)),
+            Transform::from_xyz(-(extent / 2. + i as f32 / (num_shapes - 1) as f32 * extent), 0.0, 0.0),
+        ));
     }
 }
 

--- a/src/bevy_ui.rs
+++ b/src/bevy_ui.rs
@@ -14,7 +14,7 @@ impl<const N: usize> Plugin for BlurRegionsBevyUiPlugin<N> {
 }
 
 pub fn compute_blur_regions<const N: usize>(
-    nodes: Query<(&Node, &GlobalTransform, &BorderRadius, &ViewVisibility), With<BlurRegion>>,
+    nodes: Query<(&ComputedNode, &GlobalTransform, &BorderRadius, &ViewVisibility), With<BlurRegion>>,
     mut blur_regions_cameras: Query<(&Camera, &mut BlurRegionsCamera<N>)>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
     ui_scale: Res<UiScale>,

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -77,9 +77,11 @@ impl<const N: usize> Plugin for BlurRegionsShaderPlugin<N> {
                 (prepare_blur_regions_pipelines::<N>.in_set(RenderSet::Prepare),),
             )
             .add_render_graph_node::<ViewNodeRunner<BlurRegionsNode<N>>>(Core3d, BlurRegionsLabel)
-            .add_render_graph_edges(Core3d, (Node3d::DepthOfField, BlurRegionsLabel, Node3d::Tonemapping))
+            .add_render_graph_edges(Core3d, (Node3d::Tonemapping, BlurRegionsLabel, Node3d::Smaa))
+            .add_render_graph_edges(Core3d, (BlurRegionsLabel, Node3d::Fxaa))
             .add_render_graph_node::<ViewNodeRunner<BlurRegionsNode<N>>>(Core2d, BlurRegionsLabel)
-            .add_render_graph_edges(Core2d, (Node2d::Bloom, BlurRegionsLabel, Node2d::Tonemapping));
+            .add_render_graph_edges(Core2d, (Node2d::Tonemapping, BlurRegionsLabel, Node2d::Smaa))
+            .add_render_graph_edges(Core2d, (BlurRegionsLabel, Node2d::Fxaa));
     }
 
     fn finish(&self, app: &mut App) {

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -44,7 +44,6 @@ use bevy::render::render_resource::TextureFormat;
 use bevy::render::render_resource::TextureSampleType;
 use bevy::render::renderer::RenderContext;
 use bevy::render::renderer::RenderDevice;
-use bevy::render::texture::BevyDefault;
 use bevy::render::view::ExtractedView;
 use bevy::render::view::ViewTarget;
 use bevy::render::Render;
@@ -273,6 +272,7 @@ impl<const N: usize> SpecializedRenderPipeline for BlurRegionsPipeline<N> {
                     write_mask: ColorWrites::ALL,
                 })],
             }),
+            zero_initialize_workgroup_memory: false,
         }
     }
 }

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -19,7 +19,7 @@ use bevy::render::render_graph::ViewNodeRunner;
 use bevy::render::render_resource::binding_types::sampler;
 use bevy::render::render_resource::binding_types::texture_2d;
 use bevy::render::render_resource::binding_types::uniform_buffer;
-use bevy::render::render_resource::BindGroupEntries;
+use bevy::render::render_resource::{AddressMode, BindGroupEntries};
 use bevy::render::render_resource::BindGroupLayout;
 use bevy::render::render_resource::BindGroupLayoutEntries;
 use bevy::render::render_resource::CachedRenderPipelineId;
@@ -175,7 +175,11 @@ impl<const N: usize> BlurRegionsPipeline<N> {
                 ),
             ),
         );
-        let sampler = render_device.create_sampler(&SamplerDescriptor::default());
+        let sampler = render_device.create_sampler(&SamplerDescriptor {
+            address_mode_u: AddressMode::MirrorRepeat,
+            address_mode_v: AddressMode::MirrorRepeat,
+            ..default()
+        });
 
         Self { layout, sampler }
     }


### PR DESCRIPTION
Updates the crate to Bevy 0.15, following the migration guide and migrating away from using bundles to inserting components directly (did not delete any `Bundle`s in the crate, though).

Includes #20 as I used that branch as base for this one.